### PR TITLE
Fix: Prevented WiFi from moving to AP mode in case the connection breaks

### DIFF
--- a/firmware/src/ssm_wait_for_internet.c
+++ b/firmware/src/ssm_wait_for_internet.c
@@ -139,7 +139,13 @@ void SSMWaitForInternet_Tasks(void)
             { // REVIEW: Use isElapsed kind of function
                 SYS_PRINT("INET: No Ethernet and WiFi link (after %d seconds)\r\n",
                           (SYS_TMR_TickCountGet() - wifiConnectStartTick) / SYS_TMR_TickCounterFrequencyGet());
-                _changeState(STATE_AP_ONLY);
+
+                //PATCH: WiFi should only go to AP Mode in case of invalid config, not if the connection breaks 
+                 if(!appWifiData.valid){
+                     SYS_PRINT("INET: Moving to AP Mode due to invalid Config\r\n");
+                     _changeState(STATE_AP_ONLY);
+                 }
+                
             }
             break;
 
@@ -226,7 +232,11 @@ void SSMWaitForInternet_Tasks(void)
                     ping_probe_reply_received = false;
                     if(ping_retry >= PING_RETRIES)
                     {
-                        _changeState(STATE_AP_ONLY);
+                         //PATCH: WiFi should only go to AP Mode in case of invalid config, not if the connection breaks. 
+                        if(!appWifiData.valid){
+                            SYS_PRINT("INET: Moving to AP Mode due to invalid Config\r\n");
+                            _changeState(STATE_AP_ONLY);
+                        }
                     }
                     ping_retry++;
                 }

--- a/firmware/src/ssm_wait_for_internet.c
+++ b/firmware/src/ssm_wait_for_internet.c
@@ -134,19 +134,6 @@ void SSMWaitForInternet_Tasks(void)
                 SYS_PRINT("INET: Gateway has WiFi\r\n");
                 _changeState(STATE_SETTLE);
             }
-            else if((SYS_TMR_TickCountGet() - wifiConnectStartTick) >=
-                    (SYS_TMR_TickCounterFrequencyGet() * WIFI_CONNECT_TIMEOUT))
-            { // REVIEW: Use isElapsed kind of function
-                SYS_PRINT("INET: No Ethernet and WiFi link (after %d seconds)\r\n",
-                          (SYS_TMR_TickCountGet() - wifiConnectStartTick) / SYS_TMR_TickCounterFrequencyGet());
-
-                //PATCH: WiFi should only go to AP Mode in case of invalid config, not if the connection breaks 
-                 if(!appWifiData.valid){
-                     SYS_PRINT("INET: Moving to AP Mode due to invalid Config\r\n");
-                     _changeState(STATE_AP_ONLY);
-                 }
-                
-            }
             break;
 
         case STATE_AP_ONLY:
@@ -232,11 +219,7 @@ void SSMWaitForInternet_Tasks(void)
                     ping_probe_reply_received = false;
                     if(ping_retry >= PING_RETRIES)
                     {
-                         //PATCH: WiFi should only go to AP Mode in case of invalid config, not if the connection breaks. 
-                        if(!appWifiData.valid){
-                            SYS_PRINT("INET: Moving to AP Mode due to invalid Config\r\n");
-                            _changeState(STATE_AP_ONLY);
-                        }
+                        _changeState(STATE_WAIT_FOR_NETWORK);
                     }
                     ping_retry++;
                 }


### PR DESCRIPTION
When using only WiFi, if the connection breaks, the current design is to put the the WiFi to AP Mode for a while (min 120 sec) before checking if the connection has recovered. There is no need to go to AP mode when there is valid WiFi config. We can do that by manually erasing the WiFi config. 
* This makes the recovery from WiFi issues faster since the system is constantly waiting anyway. 