### PR TITLE
Improve CI Builds

### DIFF
--- a/.ci/install-azure-cli.sh
+++ b/.ci/install-azure-cli.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list
+apt-get update
+apt-get install -y azure-cli jq

--- a/.ci/install-mplab.sh
+++ b/.ci/install-mplab.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+dpkg --add-architecture i386
+apt-get update
+apt-get install -y libc6:i386 libx11-6:i386 libxext6:i386 libstdc++6:i386 libexpat1:i386
+
+if [[ ! -d /tmp/microchip ]]
+then
+  mkdir -p /tmp/microchip
+fi
+
+## Download and Install MPLAB if needed
+if [[ ! -d /opt/microchip/mplabx/v3.45 ]]
+then
+  if [[ ! -f /tmp/microchip/MPLABX-v3.45-linux-installer.sh ]]
+  then
+    curl -sSL http://ww1.microchip.com/downloads/en/DeviceDoc/MPLABX-v3.45-linux-installer.tar | tar -xv -C /tmp/microchip
+  fi
+  sudo /tmp/microchip/MPLABX-v3.45-linux-installer.sh -- --mode unattended
+fi
+
+## Link MPLAB if needed
+if [[ ! -e /opt/microchip/mplab_ide ]]
+then
+  ln -s /opt/microchip/mplabx/v3.45/mplab_ide /opt/microchip/mplab_ide
+fi
+
+## Download and install XC32 if needed
+if [[ ! -d /opt/microchip/xc32/v1.42 ]]
+then
+  if [[ ! -f /tmp/microchip/xc32-v1.42-full-install-linux-installer.run ]]
+  then
+    curl -sSL -o /tmp/microchip/xc32-v1.42-full-install-linux-installer.run http://ww1.microchip.com/downloads/en/DeviceDoc/xc32-v1.42-full-install-linux-installer.run
+    chmod +x /tmp/microchip/xc32-v1.42-full-install-linux-installer.run
+  fi
+  sudo /tmp/microchip/xc32-v1.42-full-install-linux-installer.run -- --mode unattended --netservername ""
+fi

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+apt-get update
+apt-get install -y apt-transport-https build-essential curl git lsb-release sudo

--- a/.ci/upload-to-azure.sh
+++ b/.ci/upload-to-azure.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+if [[ -z "$AZURE_STORAGE_KEY" ]]
+then
+  exit 0
+fi
+
+container_name="the-things-gateway"
+files="firmware.hex checksums firmware-with-bootloader.hex disassembly.txt"
+
+upload() {
+  echo "Uploading files to ${1}..."
+  for file in ${files}
+  do
+    if [[ -f "$file" ]]
+    then
+      az storage blob upload --container-name "${container_name}" --name "v1/${1}/${file}" --file ./${file}
+    fi
+  done
+}
+
+if [[ ! -z "$TRAVIS_COMMIT" ]] then upload "$TRAVIS_COMMIT"; fi
+
+if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" && ! -z "$TRAVIS_BRANCH" ]] then upload "$TRAVIS_BRANCH"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,10 @@ cache:
   directories:
   - /tmp/microchip
 install:
-- sudo dpkg --add-architecture i386
-- sudo apt-get update && sudo apt-get install -y libc6:i386 libx11-6:i386 libxext6:i386 libstdc++6:i386 libexpat1:i386
-- if [[ ! -f /tmp/microchip/MPLABX-v3.45-linux-installer.tar ]]; then curl -sSL -o /tmp/microchip/MPLABX-v3.45-linux-installer.tar http://ww1.microchip.com/downloads/en/DeviceDoc/MPLABX-v3.45-linux-installer.tar; fi
-- if [[ ! -f /tmp/microchip/MPLABX-v3.45-linux-installer.sh ]]; then tar -xvf /tmp/microchip/MPLABX-v3.45-linux-installer.tar -C /tmp/microchip && chmod +x /tmp/microchip/MPLABX-v3.45-linux-installer.sh; fi
-- if [[ ! -d /opt/microchip/mplabx/v3.45 ]]; then sudo /tmp/microchip/MPLABX-v3.45-linux-installer.sh -- --mode unattended; fi
-- if [[ ! -e /opt/microchip/mplab_ide ]]; then sudo ln -s /opt/microchip/mplabx/v3.45/mplab_ide /opt/microchip/mplab_ide; fi
-- if [[ ! -f /tmp/microchip/xc32-v1.42-full-install-linux-installer.run ]]; then curl -sSL -o /tmp/microchip/xc32-v1.42-full-install-linux-installer.run http://ww1.microchip.com/downloads/en/DeviceDoc/xc32-v1.42-full-install-linux-installer.run && chmod +x /tmp/microchip/xc32-v1.42-full-install-linux-installer.run; fi
-- if [[ ! -d /opt/microchip/xc32/v1.42 ]]; then sudo /tmp/microchip/xc32-v1.42-full-install-linux-installer.run -- --mode unattended --netservername ""; fi
-- if [[ ! -z "$AZURE_STORAGE_KEY" ]]; then sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893; fi
-- if [[ ! -z "$AZURE_STORAGE_KEY" ]]; then echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/azure-cli.list; fi
-- if [[ ! -z "$AZURE_STORAGE_KEY" ]]; then sudo apt-get update && sudo apt-get install -y azure-cli; fi
+- sudo $TRAVIS_BUILD_DIR/.ci/install.sh
+- sudo $TRAVIS_BUILD_DIR/.ci/install-mplab.sh
+- sudo $TRAVIS_BUILD_DIR/.ci/install-azure-cli.sh
 script:
-- cd $TRAVIS_BUILD_DIR/firmware && ./generate_version_header.sh && ./compile.sh && ./generate_hex_with_checksum.sh && ./merge_bootloader.sh
+- pushd $TRAVIS_BUILD_DIR/firmware && ./generate_version_header.sh && ./fix_mplab.sh && ./compile.sh && ./generate_hex_with_checksum.sh && ./merge_bootloader.sh && popd
 after_success:
-- if [[ ! -z "$AZURE_STORAGE_KEY" && ! -z "$TRAVIS_COMMIT" ]]; then az storage blob upload --container-name the-things-gateway --name "v1/$TRAVIS_COMMIT/firmware.hex" --file ./firmware.hex; fi
-- if [[ ! -z "$AZURE_STORAGE_KEY" && ! -z "$TRAVIS_COMMIT" ]]; then az storage blob upload --container-name the-things-gateway --name "v1/$TRAVIS_COMMIT/checksums" --file ./checksums; fi
-- if [[ ! -z "$AZURE_STORAGE_KEY" && ! -z "$TRAVIS_COMMIT" ]]; then az storage blob upload --container-name the-things-gateway --name "v1/$TRAVIS_COMMIT/firmware-with-bootloader.hex" --file ./firmware-with-bootlader.hex; fi
-- if [[ ! -z "$AZURE_STORAGE_KEY" && ! -z "$TRAVIS_COMMIT" ]]; then az storage blob upload --container-name the-things-gateway --name "v1/$TRAVIS_COMMIT/disassembly.txt" --file ./disassembly.txt; fi
-- if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" && ! -z "$AZURE_STORAGE_KEY" && ! -z "$TRAVIS_BRANCH" ]]; then az storage blob upload --container-name the-things-gateway --name "v1/$TRAVIS_BRANCH/firmware.hex" --file ./firmware.hex; fi
-- if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" && ! -z "$AZURE_STORAGE_KEY" && ! -z "$TRAVIS_BRANCH" ]]; then az storage blob upload --container-name the-things-gateway --name "v1/$TRAVIS_BRANCH/checksums" --file ./checksums; fi
-- if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" && ! -z "$AZURE_STORAGE_KEY" && ! -z "$TRAVIS_BRANCH" ]]; then az storage blob upload --container-name the-things-gateway --name "v1/$TRAVIS_BRANCH/firmware-with-bootloader.hex" --file ./firmware-with-bootloader.hex; fi
-- if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" && ! -z "$AZURE_STORAGE_KEY" && ! -z "$TRAVIS_BRANCH" ]]; then az storage blob upload --container-name the-things-gateway --name "v1/$TRAVIS_BRANCH/disassembly.txt" --file ./disassembly.txt; fi
+- pushd $TRAVIS_BUILD_DIR/firmware && $TRAVIS_BUILD_DIR/.ci/upload-to-azure.sh && popd

--- a/firmware/generate_version_header.sh
+++ b/firmware/generate_version_header.sh
@@ -4,15 +4,27 @@
 git update-index --assume-unchanged src/system_config/TTN_Gateway_v1/version.h
 
 # get git commit
-commit=$(git rev-parse HEAD) 
+commit=$(git rev-parse HEAD)
+
+export VERSION_TYPE=${VERSION_TYPE:-$(cat version/type)}
+export VERSION_MAJOR=${VERSION_MAJOR:-$(cat version/major)}
+export VERSION_MINOR=${VERSION_MINOR:-$(cat version/minor)}
+export VERSION_PATCH=${VERSION_PATCH:-$(cat version/patch)}
+export VERSION_COMMIT=${VERSION_COMMIT:-${commit:0:8}}
+export VERSION_NAME=${VERSION_NAME:-$(cat version/name)}
+export VERSION_TIMESTAMP=${VERSION_TIMESTAMP:-$(date +%s)}
 
 # update the version.h with the values from version folder
 echo "
-#define VERSION_TYPE   $(cat version/type)
-#define VERSION_MAJOR  $(cat version/major)
-#define VERSION_MINOR  $(cat version/minor)
-#define VERSION_PATCH  $(cat version/patch)
-#define VERSION_COMMIT 0x${commit:0:8}
-#define VERSION_NAME   \"$(cat version/name)\"
-#define VERSION_TIMESTAMP $(date +%s)
+#define VERSION_TYPE      ${VERSION_TYPE}
+#define VERSION_MAJOR     ${VERSION_MAJOR}
+#define VERSION_MINOR     ${VERSION_MINOR}
+#define VERSION_PATCH     ${VERSION_PATCH}
+#define VERSION_COMMIT    0x${VERSION_COMMIT}
+#define VERSION_NAME      \"${VERSION_NAME}\"
+#define VERSION_TIMESTAMP ${VERSION_TIMESTAMP}
 " > src/system_config/TTN_Gateway_v1/version.h
+
+echo "Generated version header:"
+echo "*************************"
+echo "Firmware name: ${VERSION_NAME}, type: ${VERSION_TYPE}, version: ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}, commit: ${VERSION_COMMIT}, timestamp: ${VERSION_TIMESTAMP} ($(date -d @${VERSION_TIMESTAMP} -u +%FT%TZ))"


### PR DESCRIPTION
- Make scripts clearer by moving them into files instead of having everything in the Travis yaml file.
- Execute "mplab fix" in CI builds
- Print generated version information to build log
- Re-use existing (on Azure) builds for the same commit to avoid having the same builds with different dates.