### PR TITLE
Fix/keep existing wifi config

### DIFF
--- a/firmware/src/ssm_wait_for_internet.c
+++ b/firmware/src/ssm_wait_for_internet.c
@@ -25,7 +25,6 @@ typedef enum
 #define NTP_TIMEOUT 20          // seconds trying to receive NTP before waiting for network again
 
 static STATE_t  _state;
-static uint32_t wifiConnectStartTick = 0;
 static uint32_t settleStartTick      = 0;
 static uint32_t pingStartTick        = 0;
 static uint32_t wifiRetryStartTick   = 0;
@@ -79,7 +78,6 @@ static void _changeState(STATE_t newState)
     switch(newState)
     {
         case STATE_WAIT_FOR_NETWORK:
-            wifiConnectStartTick = SYS_TMR_TickCountGet();
             if(appWifiData.valid)
             {
                 APP_WIFI_INFRA_MODE();

--- a/firmware/src/ssm_wait_for_internet.c
+++ b/firmware/src/ssm_wait_for_internet.c
@@ -19,7 +19,7 @@ typedef enum
 } STATE_t;
 
 #define WIFI_CONNECT_TIMEOUT 10 // seconds before switching to AP mode
-#define PING_TIMEOUT 4          // seconds before retry a ping
+#define PING_TIMEOUT 60          // seconds before retry a ping
 #define PING_RETRIES 2          // retries before giving up
 #define WIFI_RETRY_TIMEOUT 120  // seconds before retrying INFRA mode again if WiFi data valid
 #define NTP_TIMEOUT 20          // seconds trying to receive NTP before waiting for network again
@@ -211,7 +211,7 @@ void SSMWaitForInternet_Tasks(void)
                 if((SYS_TMR_TickCountGet() - pingStartTick) >=
                    (SYS_TMR_TickCounterFrequencyGet() * PING_TIMEOUT)) // REVIEW: Use isElapsed kind of function
                 {
-                    SYS_PRINT("INET: Ping Timeout\r\n");
+                    SYS_PRINT("INET: Ping Timeout of :%d seconds\r\n", PING_TIMEOUT);
                     pingStartTick             = SYS_TMR_TickCountGet();
                     ping_probe_sent           = false;
                     ping_probe_reply_received = false;


### PR DESCRIPTION
Copy of commit message:
```
The previous WiFi patch that restricted AP mode to only when there is no WiFi config causes issues with gateways with exisiting WiFi config.
Though the two are not directly related, the patch seems to have uncovered an existing problem.
In the current code, the WiFi ping timeout is 8s (4x2 tries). But practically, it takes 10-15s to re-connect. So, after 8s, we go to WAIT_FOR_NETWORK state where the WiFi module is restarted.
This causes a loop since everytime the pings timeout at 8s and restart the WiFi module.
By increasing the ping timeout to a higher value of 120s (60x2 tries), this issue is not observed since the WiFi connects after roughly after 15-20s.

This issue was not observed in gateways where the WiFi config was erased since the initial wait for connection already takes into account the extra time needed to establish a connection.

Two things to be considered in the future
- Select an appropriate value for the timeout based on testing instead an arbitirarily chosen value.
- Solve the actual problem of the WiFi driver (which is beyond the scope of the Application code)
```

Together with #26 this fixes #33, fixes #10 and may be related to #8 and #24