### PR TITLE
Add timeout for http socket connect

### DIFF
--- a/firmware/src/app_http_request.c
+++ b/firmware/src/app_http_request.c
@@ -162,7 +162,13 @@ void APP_HTTP_Request_Tasks(void)
             //  SYS_CONSOLE_MESSAGE("WAITING ON TCP SOCKET\r\n");
             if(!NET_PRES_SocketIsConnected(appHTTPRequestData.socket))
             {
-                // SYS_CONSOLE_MESSAGE("Error: TCP/IP not connected\r\n");
+                if(SYS_TMR_TickCountGet() - tcpTimeout >= SYS_TMR_TickCounterFrequencyGet() * 5)
+                {
+                    tcpTimeout = SYS_TMR_TickCountGet();
+                    timeout    = true;
+                    APP_HTTP_Request_CloseIfNeeded();
+                    appHTTPRequestData.state = APP_HTTP_REQUEST_ERROR;
+                }
                 break;
             }
 


### PR DESCRIPTION
When the http socket connection fails, there is no mechanism to recover from that situation and gateway stays in infinite loop. This patch adds timeout for connection so a retry can be done. This fixes gateway freezes with less reliable connectivity.