### PR TITLE
FSK and LoRa Standard channels support

### DIFF
--- a/firmware/src/app.h
+++ b/firmware/src/app.h
@@ -182,7 +182,7 @@ extern "C"
         uint8_t  rf_chain;
         uint8_t  modulation;
         uint8_t  bandwidth;
-        uint8_t  datarate;
+        uint32_t datarate;
         uint8_t  coderate;
         int32_t  rssi;
         int32_t  snr_average;

--- a/firmware/src/app_lora.c
+++ b/firmware/src/app_lora.c
@@ -445,7 +445,14 @@ static bool configureIFChain9(bool enable, uint8_t RFChain, int32_t offset_freq,
     {
         memset(&payload[2], 0x00, 9);
     }
-    return GatewayModuleInterface_sendCommandWaitAck(GATEWAY_MODULE_CMD_IF9CONFIG, payload, sizeof(payload));
+
+    // An extra undocumented byte is needed at the start of the command.
+    // The byte seems to be ignored, but is relevant for command alignment.
+    // This was discovered by checking the output of the GATEWAY_MODULE_CMD_IF9CHAIN command.
+    uint8_t extended_payload[sizeof(payload) + 1] = {0};
+    memcpy(&extended_payload[1], &payload[0], sizeof(payload));
+
+    return GatewayModuleInterface_sendCommandWaitAck(GATEWAY_MODULE_CMD_IF9CONFIG, extended_payload, sizeof(extended_payload));
 }
 
 /*

--- a/firmware/src/app_mqtt.c
+++ b/firmware/src/app_mqtt.c
@@ -513,8 +513,11 @@ int sendUplink()
     gateway.has_rssi = 1;
     memcpy(&gateway.rssi, &recv_packet.rssi, 4);
 
-    gateway.has_snr = 1;
-    memcpy(&gateway.snr, &recv_packet.snr_average, 4);
+    if(recv_packet.modulation == LORA_MOD_LORA)
+    {
+        gateway.has_snr = 1;
+        memcpy(&gateway.snr, &recv_packet.snr_average, 4);
+    }
 
     up.gateway_metadata = &gateway;
 


### PR DESCRIPTION
## Summary

This PR fixes the FSK and LoRa Standard Channels support.

## Changes

- Fix the IF chain 8 and 9 setup by adding an extra undocumented byte to the command.
  - I found this byte by retrieving the IF chain settings and seeing that they are not equivalent to the payload we are setting, and that it was missing one byte at the start, and had an extra 0 at the end. As such, I've tried to prepend a dummy byte, which worked.
- Support FSK transmissions (both TX and RX).
  - Fix the data rate reported by the RX packet. We used `uint8_t` instead of `uint32_t`, which made the returned bitrate be wrong.
  - The frequency deviation is automatically computed if not provided (v3 does not provide it).

## Testing

I am currently running these changes on my own TTKGs, both EU868 and US915. Both the FSK and the standard channel work.